### PR TITLE
Refactor profile and notification routes to use username

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,15 +1,33 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { NavLink, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/authContext";
 import Logo from "../assets/logo.svg";
 import CloseIcon from "../icons/CloseIcon";
 import MenuIcon from "../icons/MenuIcon";
 import NotificationBadge from "./NotificationBadge";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "../Firebase/Firebase";
 
 const Navbar = () => {
   const { role, logout, loading, currentUser } = useAuth();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const navigate = useNavigate();
+
+  const [userName, setUserName] = useState(null);
+
+  useEffect(() => {
+    const fetchUserName = async () => {
+      if (currentUser?.uid) {
+        const userRef = doc(db, "Users", currentUser.uid);
+        const userSnap = await getDoc(userRef);
+        if (userSnap.exists()) {
+          setUserName(userSnap.data().userName);
+        }
+      }
+    };
+
+    fetchUserName();
+  }, [currentUser]);
 
   const baseTabs = [
     { id: "home", label: "الرئيسية" },
@@ -26,15 +44,11 @@ const Navbar = () => {
 
   const beneficiaryTabs = [
     {
-      id: currentUser?.email
-        ? `beneficiary-profile/${currentUser.email}`
-        : "beneficiary-profile",
+      id: `beneficiary-profile/${userName}`,
       label: "الملف الشخصي",
     },
     {
-      id: currentUser?.email
-        ? `notifications/${currentUser.email}`
-        : "notifications",
+      id: "notifications",
       label: <NotificationBadge />,
     },
     ...baseTabs,
@@ -43,15 +57,11 @@ const Navbar = () => {
 
   const donorTabs = [
     {
-      id: currentUser?.email
-        ? `donor-profile/${currentUser.email}`
-        : "donor-profile",
+      id: `donor-profile/${userName}`,
       label: "الملف الشخصي",
     },
     {
-      id: currentUser?.email
-        ? `notifications/${currentUser.email}`
-        : "notifications",
+      id: "notifications",
       label: <NotificationBadge />,
     },
     ...baseTabs,
@@ -60,15 +70,11 @@ const Navbar = () => {
 
   const orgTabs = [
     {
-      id: currentUser?.email
-        ? `org-profile/${currentUser.email}`
-        : "org-profile",
+      id: `org-profile/${userName}`,
       label: "الملف الشخصي",
     },
     {
-      id: currentUser?.email
-        ? `notifications/${currentUser.email}`
-        : "notifications",
+      id: "notifications",
       label: <NotificationBadge />,
     },
     ...baseTabs,
@@ -94,7 +100,7 @@ const Navbar = () => {
       default:
         return guestTabs;
     }
-  }, [role, currentUser?.email]);
+  }, [role, userName]);
 
   if (loading || role === null) return null;
 

--- a/src/pages/BeneficiaryProfile.jsx
+++ b/src/pages/BeneficiaryProfile.jsx
@@ -8,7 +8,6 @@ import Loader from "../components/Loader";
 import NoData from "../components/NoData";
 import CardLayout from "../layouts/CardLayout";
 import CardsLayout from "../layouts/CardsLayout";
-import ImageIcon from "../icons/ImageIcon";
 import UserInfo from "../components/UserInfo";
 
 export default function BeneficiaryProfile() {

--- a/src/pages/DonorProfile.jsx
+++ b/src/pages/DonorProfile.jsx
@@ -8,7 +8,6 @@ import Loader from "../components/Loader";
 import NoData from "../components/NoData";
 import CardLayout from "../layouts/CardLayout";
 import CardsLayout from "../layouts/CardsLayout";
-import ImageIcon from "../icons/ImageIcon";
 import UserInfo from "../components/UserInfo";
 
 export default function DonorProfile() {

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -38,8 +38,7 @@ export default function AppRoutes() {
             <LogoIcon />
           </div>
         </div>
-      }
-    >
+      }>
       <Routes>
         <Route path="/choose-role" element={<ChooseRole />} />
         <Route path="/" element={<Home />}>
@@ -77,7 +76,7 @@ export default function AppRoutes() {
 
         {/* Donor */}
         <Route
-          path="/donor-profile/:email?"
+          path="/donor-profile/:username?"
           element={
             <ProtectedRoute allowedRoles={["متبرع"]}>
               <DonorProfile />
@@ -87,7 +86,7 @@ export default function AppRoutes() {
 
         {/* Org */}
         <Route
-          path="/org-profile/:email?"
+          path="/org-profile/:username?"
           element={
             <ProtectedRoute allowedRoles={["مؤسسة"]}>
               <OrgProfile />
@@ -97,7 +96,7 @@ export default function AppRoutes() {
 
         {/* Beneficiary || Donor || Org */}
         <Route
-          path="/notifications/:email?"
+          path="/notifications/:username?"
           element={
             <ProtectedRoute allowedRoles={["متبرع", "مؤسسة", "مستفيد"]}>
               <Notifications />


### PR DESCRIPTION
Updated Navbar and route definitions to use username instead of email for profile and notification paths. Added logic to fetch and use the username from Firestore in Navbar. Removed unused ImageIcon imports from BeneficiaryProfile and DonorProfile.