### PR TITLE
Rename SearchBar component to Searchbar

### DIFF
--- a/src/components/Searchbar.jsx
+++ b/src/components/Searchbar.jsx
@@ -1,6 +1,6 @@
 import InputField from "./InputField";
 
-export default function SearchBar({ searchTerm, setSearchTerm }) {
+export default function Searchbar({ searchTerm, setSearchTerm }) {
   return (
     <div className="my-4">
       <InputField

--- a/src/pages/Posts.jsx
+++ b/src/pages/Posts.jsx
@@ -10,7 +10,7 @@ import NoData from "../components/NoData";
 import PostCard from "../components/PostCard";
 import CardsLayout from "../layouts/CardsLayout";
 import Loader from "../components/Loader";
-import SearchBar from "../components/SearchBar";
+import Searchbar from "../components/Searchbar";
 
 export default function Posts() {
   const { role, loading } = useAuth();
@@ -76,7 +76,7 @@ export default function Posts() {
 
       {/* شريط البحث */}
       {posts.length > 0 && (
-        <SearchBar searchTerm={searchTerm} setSearchTerm={setSearchTerm} />
+        <Searchbar searchTerm={searchTerm} setSearchTerm={setSearchTerm} />
       )}
 
       {loadingPosts ? (


### PR DESCRIPTION
Renamed the SearchBar component and its imports/usage to Searchbar for consistency in naming conventions.